### PR TITLE
fix: AttributeError for numpy 1.24+ and Warning for numpy 1.20 to 1.23

### DIFF
--- a/rvc/infer/pipeline.py
+++ b/rvc/infer/pipeline.py
@@ -404,7 +404,7 @@ class Pipeline:
         ) + 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > 255] = 255
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(np.int_)
 
         return f0_coarse, f0bak
 


### PR DESCRIPTION
numpy.int was [deprecated in NumPy 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) and was [removed in NumPy 1.24](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations).

https://stackoverflow.com/questions/74946845/attributeerror-module-numpy-has-no-attribute-int